### PR TITLE
Implement number reading HTTP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,23 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/linux,python,vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=linux,python,vim
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -50,6 +70,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+pytestdebug.log
 
 # Translations
 *.mo
@@ -70,6 +91,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+doc/_build/
 
 # PyBuilder
 target/
@@ -127,3 +149,28 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pytype static type analyzer
+.pytype/
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/linux,python,vim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:latest
+ADD ./* /reading_server/
+WORKDIR /reading_server
+EXPOSE 8080
+CMD python3 /reading_server/server.py 8080

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project's goal is to create an HTTP server able to receive an integer betwe
 
 ## Executing
 
-This project is dockerized, to build the project's docker image, use the following command:
+This project is dockerized, to build the project's docker image, use the following command after having cloned this repository and `cd`ed into its directory:
 ```
 docker build -t reading_server_image .
 ```

--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ To execute the reading server inside the docker container, use:
 ```
 docker run -it --name reading_server -p 8080:8080 reading_server
 ```
+
+The server will be listening on port 8080 by default.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Number Reading Server
+
+## Description
+This project's goal is to create an HTTP server able to receive an integer between -99999 and 99999 and reply the number written in full in a json dict format.
+
+## Executing
+
+This project is dockerized, to build the project's docker image, use the following command:
+```
+docker build -t reading_server_image .
+```
+To execute the reading server inside the docker container, use:
+```
+docker run -it --name reading_server -p 8080:8080 reading_server
+```

--- a/number_reader.py
+++ b/number_reader.py
@@ -31,61 +31,65 @@ def handle_tens_and_ones(number, digits_reading, tens_reading, irregulars_readin
     return tens_ones
 
 
-## Writes a number in full in Portuguese.
-# @param number in [-99999, 99999] integer to be read.
-# @return string containing the given number written in full in Portuguese.
-def portuguese_number_reader(number):
-    portuguese = {}
-    portuguese["digits_reading"] = [
-            "um",
-            "dois",
-            "três",
-            "quatro",
-            "cinco",
-            "seis",
-            "sete",
-            "oito",
-            "nove",
-            ]
-    portuguese["tens_reading"] = [
-            "dez",
-            "vinte",
-            "trinta",
-            "quarenta",
-            "cinquenta",
-            "sessenta",
-            "setenta",
-            "oitenta",
-            "noventa",
-            ]
-    portuguese["irregulars_reading"] = {
-            0: "zero",
-            11: "onze",
-            12: "doze",
-            13: "treze",
-            14: "quatorze",
-            15: "quinze",
-            16: "dezesseis",
-            17: "dezessete",
-            18: "dezoito",
-            19: "dezenove",
-            100: "cem",
-            }
-    portuguese["hundreds_reading"] = [
-            "cento",
-            "duzentos",
-            "trezentos",
-            "quatrocentos",
-            "quinhentos",
-            "seiscentos",
-            "setecentos",
-            "oitocentos",
-            "novecentos",
-            ]
-    portuguese["filler"] = ' e '
-    portuguese["thousand_marker"] = 'mil'
-    portuguese["minus"] = "menos"
-    return number_reader(number, **portuguese)
+class Portuguese_number_reader():
+    json_key = "extenso"
+
+    ## Writes a number in full in Portuguese.
+    # @param number in [-99999, 99999] integer to be read.
+    # @return string containing the given number written in full in Portuguese.
+    @classmethod
+    def read_number(cls, number):
+        portuguese = {}
+        portuguese["digits_reading"] = [
+                "um",
+                "dois",
+                "três",
+                "quatro",
+                "cinco",
+                "seis",
+                "sete",
+                "oito",
+                "nove",
+                ]
+        portuguese["tens_reading"] = [
+                "dez",
+                "vinte",
+                "trinta",
+                "quarenta",
+                "cinquenta",
+                "sessenta",
+                "setenta",
+                "oitenta",
+                "noventa",
+                ]
+        portuguese["irregulars_reading"] = {
+                0: "zero",
+                11: "onze",
+                12: "doze",
+                13: "treze",
+                14: "quatorze",
+                15: "quinze",
+                16: "dezesseis",
+                17: "dezessete",
+                18: "dezoito",
+                19: "dezenove",
+                100: "cem",
+                }
+        portuguese["hundreds_reading"] = [
+                "cento",
+                "duzentos",
+                "trezentos",
+                "quatrocentos",
+                "quinhentos",
+                "seiscentos",
+                "setecentos",
+                "oitocentos",
+                "novecentos",
+                ]
+        portuguese["filler"] = ' e '
+        portuguese["thousand_marker"] = 'mil'
+        portuguese["minus"] = "menos"
+        return number_reader(number, **portuguese)
 
 ## Writes a number in full in the language defined by the parameters.
 # @param number in [-99999, 99999] integer to be read.

--- a/number_reader.py
+++ b/number_reader.py
@@ -26,14 +26,30 @@ def portuguese_number_reader(number):
             "oitenta",
             "noventa",
             ]
+    irregular_tens_reading = [
+            "onze",
+            "doze",
+            "treze",
+            "quatorze",
+            "quinze",
+            "dezesseis",
+            "dezessete",
+            "dezoito",
+            "dezenove",
+            ]
     filler = ' e '
-    digit = digit_reading[int(str(number)[-1])]
+    ones_digit = int(str(number)[-1])
+    ones_reading = digit_reading[ones_digit]
     if len(str(number)) == 1:
-        return digit
+        return ones_reading
     if len(str(number)) == 2:
 
-        ten = tens_reading[int(str(number)[0]) - 1]
+        tens_digit = int(str(number)[0])
+        tens = tens_reading[tens_digit - 1]
         if int(str(number)[1]) == 0:
-            return ten
+            return tens
 
-        return ten + filler + digit
+        if tens_digit == 1:
+            return irregular_tens_reading[ones_digit - 1]
+
+        return tens + filler + ones_reading

--- a/number_reader.py
+++ b/number_reader.py
@@ -58,6 +58,7 @@ def portuguese_number_reader(number):
             "noventa",
             ]
     irregulars_reading = {
+            0: "zero",
             11: "onze",
             12: "doze",
             13: "treze",
@@ -67,6 +68,7 @@ def portuguese_number_reader(number):
             17: "dezessete",
             18: "dezoito",
             19: "dezenove",
+            100: "cem",
             }
     hundreds_reading = [
             "cento",
@@ -80,18 +82,30 @@ def portuguese_number_reader(number):
             "novecentos",
             ]
     filler = ' e '
-    if number == 0:
-        return "zero"
+    thousand_marker = 'mil'
+    if number in irregulars_reading:
+        return irregulars_reading[number]
+    #only need to write zero when it is on its own
+    del irregulars_reading[0]
     tens_ones_number = int(str(number)[-2:])
     tens_ones = handle_tens_and_ones(tens_ones_number, digit_reading,
             tens_reading, irregulars_reading, filler)
     hundreds = ""
-    if len(str(number)) >= 3:
+    if len(str(number)) >= 3 and int(str(number)[-3]) != 0:
         hundreds_digit = int(str(number)[-3])
         hundreds = hundreds_reading[hundreds_digit - 1]
-        if tens_ones == "":
-            if hundreds_digit == 1:
-                hundreds = "cem"
-        else:
+        if tens_ones != "":
             hundreds += filler
-    return hundreds + tens_ones
+    thousands = ""
+    if len(str(number)) >= 4:
+        tens_one_thousands_number = int(str(number)[-5:-3])
+        tens_one_thousands = handle_tens_and_ones(tens_one_thousands_number,
+                digit_reading, tens_reading, irregulars_reading, filler)
+        if tens_one_thousands != "":
+            thousands = tens_one_thousands + " " + thousand_marker
+            if tens_one_thousands_number == 1:
+                thousands = thousand_marker
+            hundreds_digit = int(str(number)[-3]) #it may have not been defined
+            if hundreds_digit * 100 + tens_ones_number != 0:
+                thousands += filler
+    return thousands + hundreds + tens_ones

--- a/number_reader.py
+++ b/number_reader.py
@@ -1,0 +1,39 @@
+
+## Writes a number in full in Portuguese.
+# @param number in [-99999, 99999] integer to be read.
+# @return string containing the given number written in full in Portuguese.
+def portuguese_number_reader(number):
+    digit_reading = [
+            "zero",
+            "um",
+            "dois",
+            "três",
+            "quatro",
+            "cinco",
+            "seis",
+            "sete",
+            "oito",
+            "nove",
+            ]
+    tens_reading = [
+            "dez",
+            "vinte",
+            "trinta",
+            "quarenta",
+            "cinquenta",
+            "sessenta",
+            "setenta",
+            "oitenta",
+            "noventa",
+            ]
+    filler = ' e '
+    digit = digit_reading[int(str(number)[-1])]
+    if len(str(number)) == 1:
+        return digit
+    if len(str(number)) == 2:
+
+        ten = tens_reading[int(str(number)[0]) - 1]
+        if int(str(number)[1]) == 0:
+            return ten
+
+        return ten + filler + digit

--- a/number_reader.py
+++ b/number_reader.py
@@ -1,10 +1,41 @@
 
+## Writes a number containing one digit in full
+# @param number number to be written in full
+# @param digit_reading list of readings of single digits
+# @return string containing the reading in full of the number
+def handle_ones(number, digit_reading):
+    if number == 0:
+        return ""
+    return digit_reading[number - 1]
+
+## Writes a number containing two digits in full
+# @param number number to be written in full
+# @param digit_reading list of readings of single digits
+# @param tens_reading list of readings for multiples of ten
+# @param irregulars_reading dict of {irregular_number : its reading}
+# @param filler word that goes between number readings
+# @return string containing the reading in full of the number
+def handle_tens_and_ones(number, digit_reading, tens_reading, irregulars_reading, filler):
+    if number in irregulars_reading:
+        return irregulars_reading[number]
+    ones_digit = int(str(number)[-1])
+    ones = handle_ones(ones_digit, digit_reading)
+    tens_ones = ones
+    if len(str(number)) >= 2 and int(str(number)[-2]) != 0:
+        tens_digit = int(str(number)[-2])
+        tens = tens_reading[tens_digit - 1]
+        if ones_digit == 0:
+            tens_ones = tens
+        else:
+            tens_ones = tens + filler + ones
+    return tens_ones
+
+
 ## Writes a number in full in Portuguese.
 # @param number in [-99999, 99999] integer to be read.
 # @return string containing the given number written in full in Portuguese.
 def portuguese_number_reader(number):
     digit_reading = [
-            "zero",
             "um",
             "dois",
             "três",
@@ -26,17 +57,17 @@ def portuguese_number_reader(number):
             "oitenta",
             "noventa",
             ]
-    irregular_tens_reading = [
-            "onze",
-            "doze",
-            "treze",
-            "quatorze",
-            "quinze",
-            "dezesseis",
-            "dezessete",
-            "dezoito",
-            "dezenove",
-            ]
+    irregulars_reading = {
+            11: "onze",
+            12: "doze",
+            13: "treze",
+            14: "quatorze",
+            15: "quinze",
+            16: "dezesseis",
+            17: "dezessete",
+            18: "dezoito",
+            19: "dezenove",
+            }
     hundreds_reading = [
             "cento",
             "duzentos",
@@ -49,26 +80,16 @@ def portuguese_number_reader(number):
             "novecentos",
             ]
     filler = ' e '
-    ones_digit = int(str(number)[-1])
-    ones = digit_reading[ones_digit]
-    tens_ones = ""
+    if number == 0:
+        return "zero"
+    tens_ones_number = int(str(number)[-2:])
+    tens_ones = handle_tens_and_ones(tens_ones_number, digit_reading,
+            tens_reading, irregulars_reading, filler)
     hundreds = ""
-    tens_ones = ones
-    if len(str(number)) >= 2 and int(str(number)[-2]) != 0:
-        tens_digit = int(str(number)[-2])
-        tens = tens_reading[tens_digit - 1]
-        if ones_digit == 0:
-            tens_ones = tens
-        else:
-            tens_ones = tens + filler + ones
-            if tens_digit == 1:
-                tens_ones = irregular_tens_reading[ones_digit - 1]
-
     if len(str(number)) >= 3:
         hundreds_digit = int(str(number)[-3])
         hundreds = hundreds_reading[hundreds_digit - 1]
-        if tens_ones == "zero":
-            tens_ones = ""
+        if tens_ones == "":
             if hundreds_digit == 1:
                 hundreds = "cem"
         else:

--- a/number_reader.py
+++ b/number_reader.py
@@ -83,19 +83,30 @@ def portuguese_number_reader(number):
             ]
     filler = ' e '
     thousand_marker = 'mil'
+    signal = ""
+    if number < 0:
+        signal = "menos "
+        number = -number
     if number in irregulars_reading:
         return irregulars_reading[number]
     #only need to write zero when it is on its own
     del irregulars_reading[0]
+
     tens_ones_number = int(str(number)[-2:])
     tens_ones = handle_tens_and_ones(tens_ones_number, digit_reading,
             tens_reading, irregulars_reading, filler)
+
     hundreds = ""
     if len(str(number)) >= 3 and int(str(number)[-3]) != 0:
         hundreds_digit = int(str(number)[-3])
         hundreds = hundreds_reading[hundreds_digit - 1]
+        #handle irregularities
+        complete_hundred = int(str(number)[-3:])
+        if complete_hundred in irregulars_reading:
+            hundreds = irregulars_reading[complete_hundred]
         if tens_ones != "":
             hundreds += filler
+
     thousands = ""
     if len(str(number)) >= 4:
         tens_one_thousands_number = int(str(number)[-5:-3])
@@ -108,4 +119,4 @@ def portuguese_number_reader(number):
             hundreds_digit = int(str(number)[-3]) #it may have not been defined
             if hundreds_digit * 100 + tens_ones_number != 0:
                 thousands += filler
-    return thousands + hundreds + tens_ones
+    return signal + thousands + hundreds + tens_ones

--- a/number_reader.py
+++ b/number_reader.py
@@ -102,6 +102,8 @@ class Portuguese_number_reader():
 # @param minus word that represents a negative number
 # @return string containing the given number written in full.
 def number_reader(number, digits_reading, tens_reading, hundreds_reading, irregulars_reading, filler, thousand_marker, minus):
+    if not isinstance(number, int):
+        raise TypeError("number_reader: argument must be an integer number")
     if number > 99999 or number < -99999:
         raise ValueError("number_reader: number has to be in the [-99999, 99999] range.")
     signal = ""

--- a/number_reader.py
+++ b/number_reader.py
@@ -1,25 +1,25 @@
 
 ## Writes a number containing one digit in full
 # @param number number to be written in full
-# @param digit_reading list of readings of single digits
+# @param digits_reading list of readings of single digits
 # @return string containing the reading in full of the number
-def handle_ones(number, digit_reading):
+def handle_ones(number, digits_reading):
     if number == 0:
         return ""
-    return digit_reading[number - 1]
+    return digits_reading[number - 1]
 
 ## Writes a number containing two digits in full
 # @param number number to be written in full
-# @param digit_reading list of readings of single digits
+# @param digits_reading list of readings of single digits
 # @param tens_reading list of readings for multiples of ten
 # @param irregulars_reading dict of {irregular_number : its reading}
 # @param filler word that goes between number readings
 # @return string containing the reading in full of the number
-def handle_tens_and_ones(number, digit_reading, tens_reading, irregulars_reading, filler):
+def handle_tens_and_ones(number, digits_reading, tens_reading, irregulars_reading, filler):
     if number in irregulars_reading:
         return irregulars_reading[number]
     ones_digit = int(str(number)[-1])
-    ones = handle_ones(ones_digit, digit_reading)
+    ones = handle_ones(ones_digit, digits_reading)
     tens_ones = ones
     if len(str(number)) >= 2 and int(str(number)[-2]) != 0:
         tens_digit = int(str(number)[-2])
@@ -35,7 +35,8 @@ def handle_tens_and_ones(number, digit_reading, tens_reading, irregulars_reading
 # @param number in [-99999, 99999] integer to be read.
 # @return string containing the given number written in full in Portuguese.
 def portuguese_number_reader(number):
-    digit_reading = [
+    portuguese = {}
+    portuguese["digits_reading"] = [
             "um",
             "dois",
             "três",
@@ -46,7 +47,7 @@ def portuguese_number_reader(number):
             "oito",
             "nove",
             ]
-    tens_reading = [
+    portuguese["tens_reading"] = [
             "dez",
             "vinte",
             "trinta",
@@ -57,7 +58,7 @@ def portuguese_number_reader(number):
             "oitenta",
             "noventa",
             ]
-    irregulars_reading = {
+    portuguese["irregulars_reading"] = {
             0: "zero",
             11: "onze",
             12: "doze",
@@ -70,7 +71,7 @@ def portuguese_number_reader(number):
             19: "dezenove",
             100: "cem",
             }
-    hundreds_reading = [
+    portuguese["hundreds_reading"] = [
             "cento",
             "duzentos",
             "trezentos",
@@ -81,11 +82,27 @@ def portuguese_number_reader(number):
             "oitocentos",
             "novecentos",
             ]
-    filler = ' e '
-    thousand_marker = 'mil'
+    portuguese["filler"] = ' e '
+    portuguese["thousand_marker"] = 'mil'
+    portuguese["minus"] = "menos"
+    return number_reader(number, **portuguese)
+
+## Writes a number in full in the language defined by the parameters.
+# @param number in [-99999, 99999] integer to be read.
+# @param digits_reading list of readings of single digits
+# @param tens_reading list of readings for multiples of ten
+# @param hundreds_reading list of readings for multiples of a hundred
+# @param irregulars_reading dict of {irregular_number : its reading}
+# @param filler word that goes between number readings
+# @param thousand_marker word to mark the thousand digit
+# @param minus word that represents a negative number
+# @return string containing the given number written in full.
+def number_reader(number, digits_reading, tens_reading, hundreds_reading, irregulars_reading, filler, thousand_marker, minus):
+    if number > 99999 or number < -99999:
+        raise ValueError("number_reader: number has to be in the [-99999, 99999] range.")
     signal = ""
     if number < 0:
-        signal = "menos "
+        signal = minus + " "
         number = -number
     if number in irregulars_reading:
         return irregulars_reading[number]
@@ -93,7 +110,7 @@ def portuguese_number_reader(number):
     del irregulars_reading[0]
 
     tens_ones_number = int(str(number)[-2:])
-    tens_ones = handle_tens_and_ones(tens_ones_number, digit_reading,
+    tens_ones = handle_tens_and_ones(tens_ones_number, digits_reading,
             tens_reading, irregulars_reading, filler)
 
     hundreds = ""
@@ -111,7 +128,7 @@ def portuguese_number_reader(number):
     if len(str(number)) >= 4:
         tens_one_thousands_number = int(str(number)[-5:-3])
         tens_one_thousands = handle_tens_and_ones(tens_one_thousands_number,
-                digit_reading, tens_reading, irregulars_reading, filler)
+                digits_reading, tens_reading, irregulars_reading, filler)
         if tens_one_thousands != "":
             thousands = tens_one_thousands + " " + thousand_marker
             if tens_one_thousands_number == 1:

--- a/number_reader.py
+++ b/number_reader.py
@@ -37,19 +37,40 @@ def portuguese_number_reader(number):
             "dezoito",
             "dezenove",
             ]
+    hundreds_reading = [
+            "cento",
+            "duzentos",
+            "trezentos",
+            "quatrocentos",
+            "quinhentos",
+            "seiscentos",
+            "setecentos",
+            "oitocentos",
+            "novecentos",
+            ]
     filler = ' e '
     ones_digit = int(str(number)[-1])
-    ones_reading = digit_reading[ones_digit]
-    if len(str(number)) == 1:
-        return ones_reading
-    if len(str(number)) == 2:
-
-        tens_digit = int(str(number)[0])
+    ones = digit_reading[ones_digit]
+    tens_ones = ""
+    hundreds = ""
+    tens_ones = ones
+    if len(str(number)) >= 2 and int(str(number)[-2]) != 0:
+        tens_digit = int(str(number)[-2])
         tens = tens_reading[tens_digit - 1]
-        if int(str(number)[1]) == 0:
-            return tens
+        if ones_digit == 0:
+            tens_ones = tens
+        else:
+            tens_ones = tens + filler + ones
+            if tens_digit == 1:
+                tens_ones = irregular_tens_reading[ones_digit - 1]
 
-        if tens_digit == 1:
-            return irregular_tens_reading[ones_digit - 1]
-
-        return tens + filler + ones_reading
+    if len(str(number)) >= 3:
+        hundreds_digit = int(str(number)[-3])
+        hundreds = hundreds_reading[hundreds_digit - 1]
+        if tens_ones == "zero":
+            tens_ones = ""
+            if hundreds_digit == 1:
+                hundreds = "cem"
+        else:
+            hundreds += filler
+    return hundreds + tens_ones

--- a/server.py
+++ b/server.py
@@ -1,25 +1,36 @@
 #!/usr/bin/python3
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
 from sys import argv
+
+from number_reader import Portuguese_number_reader as number_reader
 
 class Reading_server(BaseHTTPRequestHandler):
 
     def do_GET(self):
-        request_line = self.requestline
-        print("Got a GET request with request line={}".format(request_line))
+        print("Got a GET request with path = {}".format(self.path))
+        try:
+            number = int(self.path[1:])
+            written_number = number_reader.read_number(number)
+        except ValueError:
+            self.send_response(400)
+            self.end_headers()
+            return
         self.send_response(200)
+        self.send_header("Content-type", "MIME type: application/json")
         self.end_headers()
-        #codes:
-            #successful: 200
-            #client error: 400
+        json_key = number_reader.json_key
+        response = {json_key: written_number}
+        self.wfile.write(json.dumps(response).encode('utf-8'))
 
-def run(server_class=HTTPServer, handler_class=Reading_server, port=8080):
+def run(port=8080):
     server_address = ('', port)
-    httpd = server_class(server_address, handler_class)
+    httpd = HTTPServer(server_address, Reading_server)
     try:
         print("Reading server: starting server")
         print("Reading server: listening on port {}".format(str(port)))
+        print("Reading server: interrupt process to close server")
         httpd.serve_forever()
     except KeyboardInterrupt:
         pass

--- a/server.py
+++ b/server.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from sys import argv
+
+class Reading_server(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        request_line = self.requestline
+        print("Got a GET request with request line={}".format(request_line))
+        self.send_response(200)
+        self.end_headers()
+        #codes:
+            #successful: 200
+            #client error: 400
+
+def run(server_class=HTTPServer, handler_class=Reading_server, port=8080):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    try:
+        print("Reading server: starting server")
+        print("Reading server: listening on port {}".format(str(port)))
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+    print("Reading server: closed successfully")
+
+if __name__ == "__main__":
+    if len(argv) == 2:
+        run(port=int(argv[1]))
+    else:
+        run()

--- a/test_number_reader.py
+++ b/test_number_reader.py
@@ -1,123 +1,115 @@
 import unittest
-from number_reader import portuguese_number_reader as reader
+from number_reader import Portuguese_number_reader as reader
 
 class Portuguese_number_reader_test(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.correct_digits = ['zero', 'um', 'dois', 'três', 'quatro', 'cinco',
-                'seis', 'sete', 'oito', 'nove']
-
-        cls.correct_tens = ['dez', 'vinte', 'trinta', 'quarenta', 'cinquenta',
-                'sessenta', 'setenta', 'oitenta', 'noventa']
-
-        cls.correct_irregular_tens = ['onze', 'doze', 'treze', 'quatorze', 'quinze',
-                'dezesseis', 'dezessete', 'dezoito', 'dezenove']
-
-        cls.correct_hundreds = ['duzentos', 'trezentos', 'quatrocentos', 'quinhentos',
-                'seiscentos', 'setecentos', 'oitocentos', 'novecentos']
-
-        cls.filler = 'e'
-
     def test_all_digits(self):
         results = []
-        for number in range(len(self.correct_digits)):
-            reading = reader(number)
+        correct_digits = ['zero', 'um', 'dois', 'três', 'quatro', 'cinco',
+                'seis', 'sete', 'oito', 'nove']
+        for number in range(len(correct_digits)):
+            reading = reader.read_number(number)
             results.append(reading)
-        self.assertListEqual(results, self.correct_digits)
+        self.assertListEqual(results, correct_digits)
 
     def test_all_tens(self):
         results = []
-        for number in range(len(self.correct_tens)):
-            reading = reader((number + 1) * 10)
+        correct_tens = ['dez', 'vinte', 'trinta', 'quarenta', 'cinquenta',
+                'sessenta', 'setenta', 'oitenta', 'noventa']
+        for number in range(len(correct_tens)):
+            reading = reader.read_number((number + 1) * 10)
             results.append(reading)
-        self.assertListEqual(results, self.correct_tens)
+        self.assertListEqual(results, correct_tens)
 
     def test_regular_composite_ten(self):
         number = 83
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "oitenta e três"
         self.assertEqual(result, correct)
 
     def test_all_irregular_tens(self):
         results = []
-        for number in range(len(self.correct_irregular_tens)):
-            reading = reader(11 + number)
+        correct_irregular_tens = ['onze', 'doze', 'treze', 'quatorze', 'quinze',
+                'dezesseis', 'dezessete', 'dezoito', 'dezenove']
+        for number in range(len(correct_irregular_tens)):
+            reading = reader.read_number(11 + number)
             results.append(reading)
-        self.assertListEqual(results, self.correct_irregular_tens)
+        self.assertListEqual(results, correct_irregular_tens)
 
     def test_all_hundreds(self):
         results = []
-        for number in range(len(self.correct_hundreds)):
-            reading = reader((number + 2) * 100)
+        correct_hundreds = ['duzentos', 'trezentos', 'quatrocentos', 'quinhentos',
+                'seiscentos', 'setecentos', 'oitocentos', 'novecentos']
+        for number in range(len(correct_hundreds)):
+            reading = reader.read_number((number + 2) * 100)
             results.append(reading)
-        self.assertListEqual(results, self.correct_hundreds)
+        self.assertListEqual(results, correct_hundreds)
 
     def test_composite_one_hundred(self):
         number = 183
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "cento e oitenta e três"
         self.assertEqual(result, correct)
 
     def test_irregular_hundred(self):
         number = 100
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "cem"
         self.assertEqual(result, correct)
 
     def test_composite_thousand(self):
         number = 3254
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "três mil e duzentos e cinquenta e quatro"
         self.assertEqual(result, correct)
 
     def test_ten_thousand_alone(self):
         number = 18000
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "dezoito mil"
         self.assertEqual(result, correct)
 
     def test_ten_thousand_and_hundred(self):
         number = 10900
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "dez mil e novecentos"
         self.assertEqual(result, correct)
 
     def test_ten_thousand_and_ten(self):
         number = 40091
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "quarenta mil e noventa e um"
         self.assertEqual(result, correct)
 
     def test_one_thousand_alone(self):
         number = 1000
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "mil"
         self.assertEqual(result, correct)
 
     def test_one_thousand_and_digit(self):
         number = 1006
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "mil e seis"
         self.assertEqual(result, correct)
 
-    def test_one_thousand_and_digit(self):
+    def test_one_thousand_and_hundred(self):
         number = 1100
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "mil e cem"
         self.assertEqual(result, correct)
 
     def test_negative_one_thousand(self):
         number = -1000
-        result = reader(number)
+        result = reader.read_number(number)
         correct = "menos mil"
         self.assertEqual(result, correct)
 
     def test_out_of_range_number(self):
         number = 150000
-        self.assertRaises(ValueError, reader, number)
+        self.assertRaises(ValueError, reader.read_number, number)
         number = -150000
-        self.assertRaises(ValueError, reader, number)
+        self.assertRaises(ValueError, reader.read_number, number)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_number_reader.py
+++ b/test_number_reader.py
@@ -13,6 +13,10 @@ class Portuguese_number_reader_test(unittest.TestCase):
 
         cls.correct_irregular_tens = ['onze', 'doze', 'treze', 'quatorze', 'quinze',
                 'dezesseis', 'dezessete', 'dezoito', 'dezenove']
+
+        cls.correct_hundreds = ['duzentos', 'trezentos', 'quatrocentos', 'quinhentos',
+                'seiscentos', 'setecentos', 'oitocentos', 'novecentos']
+
         cls.filler = 'e'
 
     def test_all_digits(self):
@@ -41,6 +45,26 @@ class Portuguese_number_reader_test(unittest.TestCase):
             reading = reader(11 + number)
             results.append(reading)
         self.assertListEqual(results, self.correct_irregular_tens)
+
+    def test_all_hundreds(self):
+        #import pdb; pdb.set_trace()
+        results = []
+        for number in range(len(self.correct_hundreds)):
+            reading = reader((number + 2) * 100)
+            results.append(reading)
+        self.assertListEqual(results, self.correct_hundreds)
+
+    def test_composite_one_hundred(self):
+        number = 183
+        result = reader(number)
+        correct = "cento e oitenta e três"
+        self.assertEqual(result, correct)
+
+    def test_irregular_hundred(self):
+        number = 100
+        result = reader(number)
+        correct = "cem"
+        self.assertEqual(result, correct)
 
 
 

--- a/test_number_reader.py
+++ b/test_number_reader.py
@@ -91,7 +91,6 @@ class Portuguese_number_reader_test(unittest.TestCase):
 
     def test_one_thousand_alone(self):
         number = 1000
-        #import pdb; pdb.set_trace()
         result = reader(number)
         correct = "mil"
         self.assertEqual(result, correct)
@@ -114,6 +113,11 @@ class Portuguese_number_reader_test(unittest.TestCase):
         correct = "menos mil"
         self.assertEqual(result, correct)
 
+    def test_out_of_range_number(self):
+        number = 150000
+        self.assertRaises(ValueError, reader, number)
+        number = -150000
+        self.assertRaises(ValueError, reader, number)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_number_reader.py
+++ b/test_number_reader.py
@@ -102,5 +102,18 @@ class Portuguese_number_reader_test(unittest.TestCase):
         correct = "mil e seis"
         self.assertEqual(result, correct)
 
+    def test_one_thousand_and_digit(self):
+        number = 1100
+        result = reader(number)
+        correct = "mil e cem"
+        self.assertEqual(result, correct)
+
+    def test_negative_one_thousand(self):
+        number = -1000
+        result = reader(number)
+        correct = "menos mil"
+        self.assertEqual(result, correct)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_number_reader.py
+++ b/test_number_reader.py
@@ -47,7 +47,6 @@ class Portuguese_number_reader_test(unittest.TestCase):
         self.assertListEqual(results, self.correct_irregular_tens)
 
     def test_all_hundreds(self):
-        #import pdb; pdb.set_trace()
         results = []
         for number in range(len(self.correct_hundreds)):
             reading = reader((number + 2) * 100)
@@ -66,7 +65,42 @@ class Portuguese_number_reader_test(unittest.TestCase):
         correct = "cem"
         self.assertEqual(result, correct)
 
+    def test_composite_thousand(self):
+        number = 3254
+        result = reader(number)
+        correct = "três mil e duzentos e cinquenta e quatro"
+        self.assertEqual(result, correct)
 
+    def test_ten_thousand_alone(self):
+        number = 18000
+        result = reader(number)
+        correct = "dezoito mil"
+        self.assertEqual(result, correct)
+
+    def test_ten_thousand_and_hundred(self):
+        number = 10900
+        result = reader(number)
+        correct = "dez mil e novecentos"
+        self.assertEqual(result, correct)
+
+    def test_ten_thousand_and_ten(self):
+        number = 40091
+        result = reader(number)
+        correct = "quarenta mil e noventa e um"
+        self.assertEqual(result, correct)
+
+    def test_one_thousand_alone(self):
+        number = 1000
+        #import pdb; pdb.set_trace()
+        result = reader(number)
+        correct = "mil"
+        self.assertEqual(result, correct)
+
+    def test_one_thousand_and_digit(self):
+        number = 1006
+        result = reader(number)
+        correct = "mil e seis"
+        self.assertEqual(result, correct)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_number_reader.py
+++ b/test_number_reader.py
@@ -1,0 +1,37 @@
+import unittest
+from number_reader import portuguese_number_reader as reader
+
+class Portuguese_number_reader_test(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.correct_digits = ['zero', 'um', 'dois', 'três', 'quatro', 'cinco',
+                'seis', 'sete', 'oito', 'nove']
+
+        cls.correct_tens = ['dez', 'vinte', 'trinta', 'quarenta', 'cinquenta',
+                'sessenta', 'setenta', 'oitenta', 'noventa']
+        cls.filler = 'e'
+
+    def test_all_digits(self):
+        results = []
+        for number in range(len(self.correct_digits)):
+            reading = reader(number)
+            results.append(reading)
+        self.assertListEqual(results, self.correct_digits)
+
+    def test_all_tens(self):
+        results = []
+        for number in range(len(self.correct_tens)):
+            reading = reader((number + 1) * 10)
+            results.append(reading)
+        self.assertListEqual(results, self.correct_tens)
+
+    def test_regular_composite_ten(self):
+        number = 83
+        result = reader(number)
+        correct = "oitenta e três"
+        self.assertEqual(result, correct)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_number_reader.py
+++ b/test_number_reader.py
@@ -10,6 +10,9 @@ class Portuguese_number_reader_test(unittest.TestCase):
 
         cls.correct_tens = ['dez', 'vinte', 'trinta', 'quarenta', 'cinquenta',
                 'sessenta', 'setenta', 'oitenta', 'noventa']
+
+        cls.correct_irregular_tens = ['onze', 'doze', 'treze', 'quatorze', 'quinze',
+                'dezesseis', 'dezessete', 'dezoito', 'dezenove']
         cls.filler = 'e'
 
     def test_all_digits(self):
@@ -31,6 +34,14 @@ class Portuguese_number_reader_test(unittest.TestCase):
         result = reader(number)
         correct = "oitenta e três"
         self.assertEqual(result, correct)
+
+    def test_all_irregular_tens(self):
+        results = []
+        for number in range(len(self.correct_irregular_tens)):
+            reading = reader(11 + number)
+            results.append(reading)
+        self.assertListEqual(results, self.correct_irregular_tens)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request addresses the implementation of the number reading HTTP server.
It receives a GET request with a integer between -99999 and 99999 and replies with a json dict with key "extenso" and the reading of the number written in full in Portuguese.

I would like feedback on the code, especially about its structure, HTTP server code and ways to test the HTTP server code.

Thank you.